### PR TITLE
Change "vectors of objects" to "vectors of pointers"

### DIFF
--- a/pitots_cells_threads/CellBoardThread.h
+++ b/pitots_cells_threads/CellBoardThread.h
@@ -80,5 +80,5 @@ public:
     printf("@\n");
   }
   private:
-    bool _cells_ready = 0;
+    int _cells_ready = 0;
 };

--- a/pitots_cells_threads/CellBoardThread.h
+++ b/pitots_cells_threads/CellBoardThread.h
@@ -10,11 +10,11 @@ public:
 
   CellBoardThread() :
     cells{
-      new Cell(3, 4, 213.0, "Celula_Horizontal"),
-      new Cell(5, 6, 213.0, "Celula_FrontalDireita"),
-      new Cell(7, 8, 213.0, "Celula_FrontalEsquerda"),
-      new Cell(9, 10, 213.0, "Celula_TraseiraDireita"),
-      new Cell(11, 12, 213.0, "Celula_TraseiraEsquerda")
+      new Cell(3, 4, 213.0, "CH"),
+      new Cell(5, 6, 213.0, "CFD"),
+      new Cell(7, 8, 213.0, "CFE"),
+      new Cell(9, 10, 213.0, "CTD"),
+      new Cell(11, 12, 213.0, "CTE")
     }
     {
       initialize();

--- a/pitots_cells_threads/CellBoardThread.h
+++ b/pitots_cells_threads/CellBoardThread.h
@@ -6,15 +6,15 @@ class CellBoardThread: public Thread
 {
 public:
   float calibrationTime = 5000; // tare preciscion can be improved by adding a few seconds of stabilising time
-  std::vector<Cell> cells;
+  std::vector<Cell*> cells;
 
   CellBoardThread() :
     cells{
-      Cell(3, 4, 213.0, "Celula_Horizontal"),
-      Cell(5, 6, 213.0, "Celula_FrontalDireita"),
-      Cell(7, 8, 213.0, "Celula_FrontalEsquerda"),
-      Cell(9, 10, 213.0, "Celula_TraseiraDireita"),
-      Cell(11, 12, 213.0, "Celula_TraseiraEsquerda")
+      new Cell(3, 4, 213.0, "Celula_Horizontal"),
+      new Cell(5, 6, 213.0, "Celula_FrontalDireita"),
+      new Cell(7, 8, 213.0, "Celula_FrontalEsquerda"),
+      new Cell(9, 10, 213.0, "Celula_TraseiraDireita"),
+      new Cell(11, 12, 213.0, "Celula_TraseiraEsquerda")
     }
     {
       initialize();
@@ -22,15 +22,15 @@ public:
 
   void initialize(){
 
-    for (Cell& cell : cells){
-      cell.begin();
+    for (auto cell : cells){
+      cell->begin();
     }
 
     while (_cells_ready < 5){
       _cells_ready = 0;
-      for (Cell& cell : cells){
-        if(!cell.is_ready){
-          cell.is_ready = cell.startMultiple(calibrationTime);
+      for (auto cell : cells){
+        if(!cell->is_ready){
+          cell->is_ready = cell->startMultiple(calibrationTime);
         }
         else {
           _cells_ready += 1;
@@ -39,8 +39,8 @@ public:
     }
 
     // Calibrate cells
-    for (Cell& cell : cells){
-      cell.setCalFactor(cell.cal_factor);
+    for (auto cell : cells){
+      cell->setCalFactor(cell->cal_factor);
     }
 
     tareCells();
@@ -48,34 +48,34 @@ public:
 
   void tareCells(){
     // tare cells
-    for (Cell& cell : cells){
-      cell.tareNoDelay();
+    for (auto cell : cells){
+      cell->tareNoDelay();
     }
   }
 
   void run(){
     // Update data on cells
-    for (Cell& cell : cells){
-      cell.update();
+    for (auto cell : cells){
+      cell->update();
     }
 
-    for (Cell& cell : cells){
-      cell.updateForce();
+    for (auto cell : cells){
+      cell->updateForce();
     }
 
     runned();
   }
 
   void printCells(){
-    for (Cell& cell : cells){
-      printf("%f\t", cell.force);
+    for (auto cell : cells){
+      printf("%f\t", cell->force);
     }
   }
 
   void sendCells(){
     printf("!");
-    for (Cell& cell : cells){
-      printf("%s=%f;", cell.apelido.c_str(), cell.force);
+    for (auto cell : cells){
+      printf("%s=%f;", cell->apelido.c_str(), cell->force);
     }
     printf("@\n");
   }

--- a/pitots_cells_threads/CellBoardThread.h
+++ b/pitots_cells_threads/CellBoardThread.h
@@ -6,7 +6,7 @@ class CellBoardThread: public Thread
 {
 public:
   float calibrationTime = 5000; // tare preciscion can be improved by adding a few seconds of stabilising time
-  std::vector<Cell*> cells;
+  Cell* cells[5];
 
   CellBoardThread() :
     cells{

--- a/pitots_cells_threads/Pitot.h
+++ b/pitots_cells_threads/Pitot.h
@@ -3,10 +3,10 @@
 class Pitot
 {
     public:
+        String apelido;
         float Voltage = 0.0;
         int16_t adc = 0;
         int adc_port;
-        String apelido;
         Adafruit_ADS1015 &ads;
         Pitot(int adc_port, String apelido, Adafruit_ADS1015 &ads){};
 

--- a/pitots_cells_threads/PitotBoardThread.h
+++ b/pitots_cells_threads/PitotBoardThread.h
@@ -11,10 +11,10 @@ class PitotBoardThread: public Thread
     PitotBoardThread(byte adress) :
       ads(adress),
       pitots{
-        new Pitot(0, "pitot0", ads),
-        new Pitot(1, "pitot1", ads),
-        new Pitot(2, "pitot2", ads),
-        new Pitot(3, "pitot3", ads)
+        new Pitot(0, "P00", ads),
+        new Pitot(1, "P01", ads),
+        new Pitot(2, "P02", ads),
+        new Pitot(3, "P03", ads)
       }
       {
         initialize();

--- a/pitots_cells_threads/PitotBoardThread.h
+++ b/pitots_cells_threads/PitotBoardThread.h
@@ -6,7 +6,7 @@
 class PitotBoardThread: public Thread
 {
   public:
-    std::vector<Pitot*> pitots;
+    Pitot* pitots[4];
 
     PitotBoardThread(byte adress) :
       ads(adress),

--- a/pitots_cells_threads/PitotBoardThread.h
+++ b/pitots_cells_threads/PitotBoardThread.h
@@ -6,15 +6,15 @@
 class PitotBoardThread: public Thread
 {
   public:
-    std::vector<Pitot> pitots;
+    std::vector<Pitot*> pitots;
 
     PitotBoardThread(byte adress) :
       ads(adress),
       pitots{
-        Pitot(0, "pitot0", ads),
-        Pitot(1, "pitot1", ads),
-        Pitot(2, "pitot2", ads),
-        Pitot(3, "pitot3", ads)
+        new Pitot(0, "pitot0", ads),
+        new Pitot(1, "pitot1", ads),
+        new Pitot(2, "pitot2", ads),
+        new Pitot(3, "pitot3", ads)
       }
       {
         initialize();
@@ -25,8 +25,8 @@ class PitotBoardThread: public Thread
     }
 
     void run(){
-      for (Pitot& pitot : pitots){
-        pitot.updateVoltage();
+      for (auto pitot : pitots){
+        pitot->updateVoltage();
       }
 
       runned();
@@ -34,15 +34,15 @@ class PitotBoardThread: public Thread
 
     void printPitots(){
 
-      for (Pitot& pitot : pitots){
-        printf("%f\t", pitot.Voltage);
+      for (auto pitot : pitots){
+        printf("%f\t", pitot->Voltage);
       }
     }
 
     void sendPitots(){
       printf("!");
-      for (Pitot& pitot : pitots){
-        printf("%s=%f;", pitot.apelido.c_str(), pitot.Voltage);
+      for (auto pitot : pitots){
+        printf("%s=%f;", pitot->apelido.c_str(), pitot->Voltage);
       }
       printf("@\n");
     }

--- a/pitots_cells_threads/pitots_cells_threads.ino
+++ b/pitots_cells_threads/pitots_cells_threads.ino
@@ -17,7 +17,7 @@ bool newData = false;
 
 ThreadController controller = ThreadController();
 CellBoardThread* cell_board = new CellBoardThread();
-std::vector<PitotBoardThread*> pitot_boards = {
+PitotBoardThread* pitot_boards[2] = {
   new PitotBoardThread(0x48),
 //  new PitotBoardThread(0x49),
 //  new PitotBoardThread(0x4A),

--- a/pitots_cells_threads/pitots_cells_threads.ino
+++ b/pitots_cells_threads/pitots_cells_threads.ino
@@ -5,23 +5,23 @@
 #include "PitotBoardThread.h"
 #include "CellBoardThread.h"
 
-bool use_pitots = false;
+bool use_pitots = true;
 bool use_cells = true;
-bool print_pitots = false;
+bool print_pitots = true;
 bool print_cells = true;
-bool send_outside = false;
+bool send_outside = true;
 
 static const byte numChars = 32;
 char receivedChars[numChars];
 bool newData = false;
 
 ThreadController controller = ThreadController();
-CellBoardThread cell_board = CellBoardThread();
-std::vector<PitotBoardThread> pitot_boards = {
-  PitotBoardThread(0x48),
-  PitotBoardThread(0x49),
-  PitotBoardThread(0x4A),
-  PitotBoardThread(0x4B)
+CellBoardThread* cell_board = new CellBoardThread();
+std::vector<PitotBoardThread*> pitot_boards = {
+  new PitotBoardThread(0x48),
+  new PitotBoardThread(0x49),
+  new PitotBoardThread(0x4A),
+  new PitotBoardThread(0x4B)
 };
 
 
@@ -40,36 +40,36 @@ void loop(){
 
 void initializeThreads(){
   if (use_pitots){
-    for (PitotBoardThread& pitot_board : pitot_boards){
-      pitot_board.setInterval(1);
-      controller.add(&pitot_board);
+    for (auto pitot_board : pitot_boards){
+      pitot_board->setInterval(1);
+      controller.add(pitot_board);
     }
   }
 
   if(use_cells){
-    cell_board.setInterval(1);
-    controller.add(&cell_board);
+    cell_board->setInterval(1);
+    controller.add(cell_board);
   }
 }
 
 void printData(){
   if (print_pitots){
-    for (PitotBoardThread& pitot_board : pitot_boards){
-      pitot_board.printPitots();
+    for (auto pitot_board : pitot_boards){
+      pitot_board->printPitots();
     }
   }
   if (print_cells){
-    cell_board.printCells();
+    cell_board->printCells();
   }
   printf("\n");
 }
 
 void sendData(){
   if (send_outside){
-    for (PitotBoardThread& pitot_board : pitot_boards){
-      pitot_board.sendPitots();
+    for (auto pitot_board : pitot_boards){
+      pitot_board->sendPitots();
     }
-    cell_board.sendCells();
+    cell_board->sendCells();
   }
 }
 
@@ -108,7 +108,6 @@ void receiveCommands() {
 void interpretCommands(){
   if (newData){
     if (strcmp(receivedChars, "tc") == 0) {
-      cell_board.tareCells();
     }
     if (strcmp(receivedChars, "pp") == 0) {
       print_pitots = !print_pitots;

--- a/pitots_cells_threads/pitots_cells_threads.ino
+++ b/pitots_cells_threads/pitots_cells_threads.ino
@@ -108,6 +108,7 @@ void receiveCommands() {
 void interpretCommands(){
   if (newData){
     if (strcmp(receivedChars, "tc") == 0) {
+      cell_board->tareCells();
     }
     if (strcmp(receivedChars, "pp") == 0) {
       print_pitots = !print_pitots;

--- a/pitots_cells_threads/pitots_cells_threads.ino
+++ b/pitots_cells_threads/pitots_cells_threads.ino
@@ -19,9 +19,9 @@ ThreadController controller = ThreadController();
 CellBoardThread* cell_board = new CellBoardThread();
 std::vector<PitotBoardThread*> pitot_boards = {
   new PitotBoardThread(0x48),
-  new PitotBoardThread(0x49),
-  new PitotBoardThread(0x4A),
-  new PitotBoardThread(0x4B)
+//  new PitotBoardThread(0x49),
+//  new PitotBoardThread(0x4A),
+//  new PitotBoardThread(0x4B)
 };
 
 

--- a/pitots_cells_threads/pitots_cells_threads.ino
+++ b/pitots_cells_threads/pitots_cells_threads.ino
@@ -5,11 +5,11 @@
 #include "PitotBoardThread.h"
 #include "CellBoardThread.h"
 
-bool use_pitots = true;
+bool use_pitots = false;
 bool use_cells = true;
-bool print_pitots = true;
+bool print_pitots = false;
 bool print_cells = true;
-bool send_outside = true;
+bool send_outside = false;
 
 static const byte numChars = 32;
 char receivedChars[numChars];

--- a/pitots_cells_threads/pitots_cells_threads.ino
+++ b/pitots_cells_threads/pitots_cells_threads.ino
@@ -17,7 +17,7 @@ bool newData = false;
 
 ThreadController controller = ThreadController();
 CellBoardThread* cell_board = new CellBoardThread();
-PitotBoardThread* pitot_boards[2] = {
+PitotBoardThread* pitot_boards[1] = {
   new PitotBoardThread(0x48),
 //  new PitotBoardThread(0x49),
 //  new PitotBoardThread(0x4A),

--- a/pitots_cells_threads/pitots_cells_threads.ino
+++ b/pitots_cells_threads/pitots_cells_threads.ino
@@ -41,13 +41,13 @@ void loop(){
 void initializeThreads(){
   if (use_pitots){
     for (auto pitot_board : pitot_boards){
-      pitot_board->setInterval(1);
+      pitot_board->setInterval(10);
       controller.add(pitot_board);
     }
   }
 
   if(use_cells){
-    cell_board->setInterval(1);
+    cell_board->setInterval(50);
     controller.add(cell_board);
   }
 }


### PR DESCRIPTION
Modification aiming to prevent intensive memory use, which leads to unresponsive board.

Previous implementation was using regular object passing on vectors, which copies objects and so leads to intensive memory use. Passing arrays (could be vectors) of pointers prevent that, by not copying objects over and over.