### PR TITLE
Calibrate cell's forces inside the Master telemetria code

### DIFF
--- a/pitots_cells_threads/pitots_cells_threads.ino
+++ b/pitots_cells_threads/pitots_cells_threads.ino
@@ -93,11 +93,11 @@ public:
     }
 
     // Calibrate cells
-    Celula_Horizontal.setCalFactor(629.0); // user set calibration factor (float)
-    Celula_FrontalDireita.setCalFactor(217.0); // user set calibration factor (float)
-    Celula_FrontalEsquerda.setCalFactor(192.0); // user set calibration factor (float)
-    Celula_TraseiraDireita.setCalFactor(211.0); // user set calibration factor (float)
-    Celula_TraseiraEsquerda.setCalFactor(210.0); // user set calibration factor (float)
+    Celula_Horizontal.setCalFactor(1.0); // user set calibration factor (float)
+    Celula_FrontalDireita.setCalFactor(1.0); // user set calibration factor (float)
+    Celula_FrontalEsquerda.setCalFactor(1.0); // user set calibration factor (float)
+    Celula_TraseiraDireita.setCalFactor(1.0); // user set calibration factor (float)
+    Celula_TraseiraEsquerda.setCalFactor(1.0); // user set calibration factor (float)
 
     Serial.println("Startup and tare are complete");
   }


### PR DESCRIPTION
This is a change of concept, so very important. 

Previous implementation assumed that the data coming from the Slave (Arduino) was already calibrated, so the Master only assumed it received correct values, on the correct unit, and used it.  This was to make sure the Slave was could be used by itself, without changes.

The problem with this previous implementation was that it didn't allow, or allowed on a messy way, to calibrate the forces inside Master. Doing this was kind of a ugly thing, because the Master would be calibrating an already calibrated  value. If something changed on Slave (and it could/should be changed), changes on Master would need to occur also.

To prevent the "shared own", all the calibration is being transferred to Master. This will be made with the Pitot and other sensors also. This new way prevent unknown changes to occur and make sure the Master can change things as it needs.

From now on the Slave is just a "sensor middle-man", as it was supposed to be.

Calibraton factors are now on Configurador(), so them can be changed both by the user and code as it needs. Those factors are passed to the Celulas() on initialization. For now they are fixed once the code is running, but this can be changed in the future with new methods.